### PR TITLE
Feat/sign authorization

### DIFF
--- a/.changeset/spotty-points-applaud.md
+++ b/.changeset/spotty-points-applaud.md
@@ -1,0 +1,5 @@
+---
+"@xellar/kit": minor
+---
+
+add useSignAuthorizationHook

--- a/apps/react-vite/src/App.tsx
+++ b/apps/react-vite/src/App.tsx
@@ -2,9 +2,380 @@ import { useState } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
-import { useXellarAccount, useSmartAccount, useConnectModal, ConnectButton } from "@xellar/kit";
-import { useAccount, useChainId, useSignMessage, useSignTypedData, useSwitchChain, useWriteContract } from "wagmi";
+import {
+  useXellarAccount,
+  useSmartAccount,
+  useConnectModal,
+  ConnectButton,
+  useSignAuthorization,
+} from "@xellar/kit";
+import {
+  useAccount,
+  useChainId,
+  useSignMessage,
+  useSignTypedData,
+  useSwitchChain,
+  useWriteContract,
+} from "wagmi";
 import { encodeFunctionData, erc20Abi } from "viem";
+import { baseSepolia } from "viem/chains";
+const tokenABI = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "mint",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "burn",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "burnFrom",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "burnFrom",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [
+      {
+        internalType: "uint8",
+        name: "",
+        type: "uint8",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "balanceOf",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "transfer",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    name: "approve",
+    inputs: [
+      {
+        internalType: "address",
+        name: "spender",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
+
+const callABI = [
+  {
+    type: "constructor",
+    inputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      {
+        name: "calls",
+        type: "tuple[]",
+        internalType: "struct Call.CallData[]",
+        components: [
+          {
+            name: "to",
+            type: "address",
+            internalType: "address",
+          },
+          {
+            name: "value",
+            type: "uint256",
+            internalType: "uint256",
+          },
+          {
+            name: "data",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: "results",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "executeSingle",
+    inputs: [
+      {
+        name: "to",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "version",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "string",
+        internalType: "string",
+      },
+    ],
+    stateMutability: "pure",
+  },
+  {
+    type: "event",
+    name: "BatchExecuted",
+    inputs: [
+      {
+        name: "caller",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "totalCalls",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "totalValue",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "CallExecuted",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "value",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256",
+      },
+      {
+        name: "data",
+        type: "bytes",
+        indexed: false,
+        internalType: "bytes",
+      },
+      {
+        name: "result",
+        type: "bytes",
+        indexed: false,
+        internalType: "bytes",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "error",
+    name: "CallFailed",
+    inputs: [
+      {
+        name: "target",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "index",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "EmptyBatch",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ReentrancyGuardReentrantCall",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "ValueMismatch",
+    inputs: [
+      {
+        name: "expected",
+        type: "uint256",
+        internalType: "uint256",
+      },
+      {
+        name: "provided",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+  },
+  {
+    type: "error",
+    name: "ZeroAddress",
+    inputs: [],
+  },
+];
 
 function App() {
   const [count, setCount] = useState(0);
@@ -18,6 +389,7 @@ function App() {
   const { writeContractAsync } = useWriteContract();
   const chainId = useChainId();
   const account = useAccount();
+  const { signAuthorization, resetAuthorization } = useSignAuthorization();
 
   const handleWriteContract = async () => {
     try {
@@ -25,7 +397,10 @@ function App() {
         abi: erc20Abi,
         address: "0x53844F9577C2334e541Aec7Df7174ECe5dF1fCf0" as `0x${string}`,
         functionName: "approve",
-        args: ["0xCa2D0dFC23f4f4b1ee01ed727664f807c21f4505" as `0x${string}`, 1000000000000000000n],
+        args: [
+          "0xCa2D0dFC23f4f4b1ee01ed727664f807c21f4505" as `0x${string}`,
+          1000000000000000000n,
+        ],
       });
 
       console.log("Transaction successful:", hash);
@@ -37,6 +412,62 @@ function App() {
   const xellarAccount = useXellarAccount();
 
   console.log("Xellar Account:", xellarAccount);
+
+  const handleSignAuthorization = async () => {
+    try {
+      if (chainId !== baseSepolia.id) {
+        await switchChainAsync({ chainId: baseSepolia.id });
+      }
+
+      const signAuthorizationResult = await signAuthorization(
+        baseSepolia.id.toString(),
+        "0x64e2f8c98e6a85a35d279eeb853050b7ae59e1c9",
+        "self"
+      );
+      if (!signAuthorizationResult) {
+        return;
+      }
+      const transferCallData = encodeFunctionData({
+        abi: tokenABI,
+        functionName: "approve",
+        args: [account.address as `0x${string}`, 1000n],
+      });
+
+      const txHash = await writeContractAsync({
+        abi: callABI,
+        functionName: "executeSingle",
+        address: account.address as `0x${string}`,
+        args: [
+          "0x5deac602762362fe5f135fa5904351916053cf70" as `0x${string}`, // usdc hardcoded address
+          transferCallData,
+        ],
+        chainId: baseSepolia.id,
+        authorizationList: [
+          {
+            chainId: signAuthorizationResult.authorization.chainId,
+            contractAddress: signAuthorizationResult.authorization
+              .address as `0x${string}`,
+            nonce: signAuthorizationResult.authorization.nonce,
+            r: signAuthorizationResult.authorization.r as `0x${string}`,
+            s: signAuthorizationResult.authorization.s as `0x${string}`,
+            yParity: signAuthorizationResult.authorization.yParity,
+          },
+        ],
+      });
+      console.log("EIP-7702 Transaction Successfull: ", txHash);
+    } catch (error) {
+      console.error("Error signing typed data:", error);
+    }
+  };
+
+  const handleResetAuthorization = async () => {
+    try {
+      await resetAuthorization(baseSepolia.id.toString(), "self");
+      console.log("Authorization reset successfully");
+    } catch (error) {
+      console.error("Error resetting authorization:", error);
+    }
+  };
 
   const handleSignTypedData = async () => {
     try {
@@ -83,7 +514,10 @@ function App() {
     const callData = encodeFunctionData({
       abi: erc20Abi,
       functionName: "approve",
-      args: ["0xCa2D0dFC23f4f4b1ee01ed727664f807c21f4505" as `0x${string}`, 1000000000000000000n],
+      args: [
+        "0xCa2D0dFC23f4f4b1ee01ed727664f807c21f4505" as `0x${string}`,
+        1000000000000000000n,
+      ],
     });
 
     const selectedAccount = smartAccount?.accounts[0];
@@ -114,12 +548,16 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
+        <button onClick={() => setCount((count) => count + 1)}>
+          count is {count}
+        </button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
+      </p>
       {account?.address ? (
         <>
           <ConnectButton />
@@ -127,8 +565,14 @@ function App() {
             {isSigningMessage ? "Signing..." : "Sign Message"}
           </button>
           <button onClick={handleSignTypedData}>Sign Typed Data</button>
+          <button onClick={handleSignAuthorization}>Sign Authorization</button>
+          <button onClick={handleResetAuthorization}>
+            Reset Authorization
+          </button>
           <button onClick={handleWriteContract}>Write Contract</button>
-          <button onClick={handleSmartAccountSignTransaction}>Smart Account Sign Transaction</button>
+          <button onClick={handleSmartAccountSignTransaction}>
+            Smart Account Sign Transaction
+          </button>
         </>
       ) : (
         <button onClick={open}>Connect</button>

--- a/apps/react-vite/src/provider.tsx
+++ b/apps/react-vite/src/provider.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { Config, WagmiProvider } from "wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { XellarKitProvider, defaultConfig } from "@xellar/kit";
-import { liskSepolia, polygonMumbai, lisk, holesky } from "viem/chains";
+import {
+  liskSepolia,
+  polygonMumbai,
+  lisk,
+  holesky,
+  baseSepolia,
+} from "viem/chains";
 
 const walletConnectProjectId = import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID;
 
@@ -11,7 +17,7 @@ const config = defaultConfig({
   walletConnectProjectId,
   xellarAppId: import.meta.env.VITE_XELLAR_APP_ID,
   xellarEnv: "sandbox",
-  chains: [liskSepolia, polygonMumbai, lisk, holesky],
+  chains: [liskSepolia, polygonMumbai, lisk, holesky, baseSepolia],
 }) as Config;
 
 const queryClient = new QueryClient();

--- a/packages/xellar-kit/package.json
+++ b/packages/xellar-kit/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@react-oauth/google": "^0.12.1",
-    "@xellar/sdk": "4.5.2",
+    "@xellar/sdk": "4.8.0",
     "clsx": "^2.1.1",
     "input-otp": "^1.4.2",
     "js-cookie": "^3.0.5",

--- a/packages/xellar-kit/src/hooks/use-sign-authorization.ts
+++ b/packages/xellar-kit/src/hooks/use-sign-authorization.ts
@@ -1,0 +1,109 @@
+import { useCallback } from 'react';
+import { useAccount, useSendTransaction } from 'wagmi';
+
+import { useXellarSDK } from '@/components/dialog/content/passport-content/hooks';
+import { useBoundStore, useXellarAccountStore } from '@/xellar-connector/store';
+import { showNeedPermissionConfirmation } from '@/xellar-connector/transaction-confirmation';
+
+function getStoreState() {
+  const token = useBoundStore.getState().token;
+  const refreshToken = useBoundStore.getState().refreshToken;
+  const chainId = useBoundStore.getState().chainId;
+
+  if (!token || !refreshToken) {
+    throw new Error('No token found');
+  }
+
+  if (!chainId) {
+    throw new Error('No chainId found');
+  }
+
+  return { token, refreshToken, chainId };
+}
+
+export function useSignAuthorization() {
+  const { xellarSDK } = useXellarSDK();
+  const { sendTransactionAsync } = useSendTransaction();
+  const { address } = useAccount();
+  const signAuthorization = useCallback(
+    async (
+      chainId: string | number,
+      contractAddress: string,
+      executor?: string
+    ) => {
+      const { refreshToken, token } = getStoreState();
+
+      const isPermissionGranted =
+        useXellarAccountStore.getState().account?.isPermissionGranted;
+
+      if (isPermissionGranted === false) {
+        showNeedPermissionConfirmation();
+        return;
+      }
+
+      const result = await xellarSDK.wallet.signAuthorization({
+        walletToken: token,
+        refreshToken,
+        chainId,
+        contractAddress,
+        executor: executor ?? 'self'
+      });
+
+      useBoundStore.setState({
+        refreshToken: result.refreshToken,
+        token: result.walletToken
+      });
+
+      return result;
+    },
+    [xellarSDK]
+  );
+
+  const resetAuthorization = useCallback(
+    async (chainId: string | number, executor?: string) => {
+      const { refreshToken, token } = getStoreState();
+
+      const isPermissionGranted =
+        useXellarAccountStore.getState().account?.isPermissionGranted;
+
+      if (isPermissionGranted === false) {
+        showNeedPermissionConfirmation();
+        return;
+      }
+
+      const authResult = await xellarSDK.wallet.signAuthorization({
+        walletToken: token,
+        refreshToken,
+        chainId,
+        contractAddress: '0x0000000000000000000000000000000000000000',
+        executor: executor ?? 'self'
+      });
+
+      useBoundStore.setState({
+        refreshToken: authResult.refreshToken,
+        token: authResult.walletToken
+      });
+
+      await sendTransactionAsync({
+        authorizationList: [
+          {
+            chainId: authResult.authorization.chainId,
+            contractAddress: authResult.authorization.address as `0x${string}`,
+            nonce: authResult.authorization.nonce,
+            r: authResult.authorization.r as `0x${string}`,
+            s: authResult.authorization.s as `0x${string}`,
+            yParity: authResult.authorization.yParity
+          }
+        ],
+        data: '0x',
+        to: address as `0x${string}`
+      });
+    },
+    [address, sendTransactionAsync, xellarSDK.wallet]
+  );
+
+  return {
+    signAuthorization,
+    resetAuthorization
+  };
+}

--- a/packages/xellar-kit/src/index.ts
+++ b/packages/xellar-kit/src/index.ts
@@ -3,6 +3,7 @@ export { ConnectDialogStandAlone } from './components/dialog/content/connect-dia
 export { defaultConfig } from './config/default-config';
 export { useSmartAccount } from './hooks/account-abstraction';
 export { useConnectModal } from './hooks/use-connect-modal';
+export { useSignAuthorization } from './hooks/use-sign-authorization';
 export { useXellarAccount } from './hooks/use-xellar-account';
 export { useChainModal } from './hooks/useChainModal';
 export { useProfileModal } from './hooks/useProfileModal';

--- a/packages/xellar-kit/src/xellar-connector/provider-request.ts
+++ b/packages/xellar-kit/src/xellar-connector/provider-request.ts
@@ -2,6 +2,7 @@ import { Network, XellarError, XellarSDK } from '@xellar/sdk';
 import {
   Chain,
   EIP1193Parameters,
+  hexToNumber,
   hexToString,
   PublicRpcSchema,
   WalletRpcSchema
@@ -75,6 +76,45 @@ async function handleRefreshToken(xellarSDK: XellarSDK | undefined) {
   }
 }
 
+type AuthorizationListInput = Array<{
+  address: string;
+  chainId: string;
+  nonce: string;
+  r: string;
+  s: string;
+  yParity: string;
+}>;
+
+type AuthorizationListOutput = Array<{
+  address: string;
+  chainId: number;
+  nonce: number;
+  r: string;
+  s: string;
+  v: number;
+  yParity: number;
+}>;
+
+const transformAuthorizationList = (
+  authorizationList: AuthorizationListInput
+): AuthorizationListOutput => {
+  return authorizationList.map(auth => {
+    const chainId = hexToNumber(auth.chainId as `0x${string}`);
+    const nonce = hexToNumber(auth.nonce as `0x${string}`);
+    const yParity = hexToNumber(auth.yParity as `0x${string}`);
+
+    return {
+      address: auth.address,
+      chainId,
+      nonce,
+      r: auth.r,
+      s: auth.s,
+      v: yParity + 27,
+      yParity
+    };
+  });
+};
+
 export async function handleRequest(
   xellarSDK: XellarSDK | undefined,
   { method, params }: EIP1193Parameters<RPCSchema>,
@@ -85,8 +125,6 @@ export async function handleRequest(
   await handleRefreshToken(xellarSDK);
   const isPermissionGranted =
     useXellarAccountStore.getState().account?.isPermissionGranted;
-
-  console.log({ isPermissionGranted });
 
   switch (method) {
     case 'personal_sign': {
@@ -407,6 +445,13 @@ export async function handleRequest(
         // At this point, the dialog will show a loading indicator
         // since the confirmation Promise has resolved but the
         // dialog's onConfirm Promise is still pending
+        // Transform authorization list from hex strings to proper format
+        const transformedAuthorizationList = request.authorizationList
+          ? transformAuthorizationList(
+              request.authorizationList as AuthorizationListInput
+            )
+          : undefined;
+
         const result = await xellarSDK?.wallet?.sendTransaction({
           transaction: {
             from: request.from as `0x${string}`,
@@ -414,7 +459,8 @@ export async function handleRequest(
             value: request.value,
             data: request.data ?? '0x',
             nonce: request.nonce,
-            gasPrice: request.gasPrice
+            gasPrice: request.gasPrice,
+            authorizationList: transformedAuthorizationList
           },
           network: chainMap[chainId] as Network,
           walletToken: token,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: '>=5.0.0'
         version: 5.64.2(react@19.0.0)
       '@xellar/sdk':
-        specifier: 4.5.2
-        version: 4.5.2(react-native-quick-crypto@0.7.12(react-native@0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.26.9(@babel/core@7.26.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))
+        specifier: 4.8.0
+        version: 4.8.0(react-native-quick-crypto@0.7.12(react-native@0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.26.9(@babel/core@7.26.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2628,8 +2628,8 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@xellar/sdk@4.5.2':
-    resolution: {integrity: sha512-hHi7WeyMlFQBzf4lwMeEf46TswHFWW+hFbC7BmIbmacxuVz1YzTnKXe6WiN/rXo9R7Xnfm1zqnXAEFdVemeVWA==}
+  '@xellar/sdk@4.8.0':
+    resolution: {integrity: sha512-agzWrfAjaIl2J0IcSwQfee9mtTHFd4hMj9L3iS7A6GQ+Q9bjN+xTZ205UqrGhcjUUf+YdfTQnRe4k95D0k3jHA==}
     peerDependencies:
       react-native-quick-crypto: ^0.7.6
 
@@ -8135,7 +8135,7 @@ snapshots:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
       debug: 4.4.0
-      semver: 7.7.1
+      semver: 7.7.2
       superstruct: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -8149,7 +8149,7 @@ snapshots:
       '@types/debug': 4.1.12
       debug: 4.4.0
       pony-cause: 2.1.11
-      semver: 7.6.3
+      semver: 7.7.2
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -8444,7 +8444,7 @@ snapshots:
       metro-config: 0.81.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.81.3
       readline: 1.3.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -9466,7 +9466,7 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@xellar/sdk@4.5.2(react-native-quick-crypto@0.7.12(react-native@0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.26.9(@babel/core@7.26.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))':
+  '@xellar/sdk@4.8.0(react-native-quick-crypto@0.7.12(react-native@0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.26.9(@babel/core@7.26.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))':
     dependencies:
       axios: 1.8.1
       react-native-quick-crypto: 0.7.12(react-native@0.78.0(@babel/core@7.26.0)(@babel/preset-env@7.26.9(@babel/core@7.26.0))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
@@ -10704,7 +10704,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   external-editor@3.1.0:
@@ -12367,7 +12367,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.25.0
-      semver: 7.7.1
+      semver: 7.7.2
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -12632,8 +12632,7 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2:
-    optional: true
+  semver@7.7.2: {}
 
   send@0.19.0:
     dependencies:


### PR DESCRIPTION
# Pull Request Summary

## Overview
This PR introduces a new `useSignAuthorization` hook for EIP-7702 authorization signing functionality and updates the `@xellar/sdk` dependency to support authorization list handling in transactions.

## Changes

### 1. New `useSignAuthorization` Hook
- **Location**: `packages/xellar-kit/src/hooks/use-sign-authorization.ts`
- **Exported from**: `packages/xellar-kit/src/index.ts`

**Features:**
- `signAuthorization(chainId, contractAddress, executor?)`: Signs an authorization for a specific contract address
  - Validates permission status before signing
  - Updates tokens in the store after signing
  - Returns authorization data for use in transactions
- `resetAuthorization(chainId, executor?)`: Resets authorization by signing with zero address and sending a transaction to clear it

**Implementation details:**
- Uses `xellarSDK.wallet.signAuthorization()` from the updated SDK
- Checks `isPermissionGranted` before signing
- Shows permission confirmation dialog if needed
- Automatically updates refresh tokens and wallet tokens after signing

### 2. SDK Dependency Update
- Updated `@xellar/sdk` from `4.5.2` → `4.8.0`
- Enables authorization list support in transaction handling

### 3. Enhanced Transaction Handling
- **Location**: `packages/xellar-kit/src/xellar-connector/provider-request.ts`

**Improvements:**
- Added `transformAuthorizationList` function to convert hex strings to proper SDK format
- Integrated authorization list transformation in `eth_sendTransaction` handler
- Supports EIP-7702 authorization lists in transaction requests

### 4. Example Implementation
- Updated `apps/react-vite/src/App.tsx` with example usage
- Demonstrates signing authorization and resetting authorization

## Technical Details
- The hook integrates with existing Xellar account stores and permission checks
- Authorization lists are transformed from hex format to SDK's expected format (chainId, nonce, yParity as numbers)
- Token refresh is handled automatically after authorization operations

## Testing
The hook is demonstrated in the React Vite example app with:
- Signing authorization for a specific contract
- Resetting authorization
- Using authorization lists in contract transactions

---

This PR enables EIP-7702 authorization signing functionality in Xellar Kit and aligns with the latest SDK capabilities.

